### PR TITLE
Compare page draft bug

### DIFF
--- a/electron/ui/src/views/ScenarioCompare/ScenarioCompare.js
+++ b/electron/ui/src/views/ScenarioCompare/ScenarioCompare.js
@@ -86,6 +86,7 @@ export default function ScenarioCompare(props) {
     //check for indexes
     let tempIndexes = []
     if(compareScenarioIndexes.length === 0) {
+        // in this case maybe it makes sense to just redirect to list page
         let scenarioIds = Object.keys(scenarios)
         tempIndexes.push(scenarioIds[0])
         tempIndexes.push(scenarioIds[1])
@@ -96,7 +97,15 @@ export default function ScenarioCompare(props) {
     } else if(compareScenarioIndexes.length === 1) {
         let scenarioIds = Object.keys(scenarios)
         tempIndexes.push(compareScenarioIndexes[0])
-        tempIndexes.push(scenarioIds[0])
+        for (let scenarioId of scenarioIds) {
+            let status = scenarios[scenarioId].results.status
+            if (status === "Optimized") { 
+                tempIndexes.push(scenarioId)
+                break
+            }
+        }
+        
+        
         setCompareScenarioIndexes([tempIndexes[0],tempIndexes[1]])
         return
     }

--- a/electron/ui/src/views/ScenarioCompare/ScenarioCompareOutput.js
+++ b/electron/ui/src/views/ScenarioCompare/ScenarioCompareOutput.js
@@ -155,12 +155,12 @@ export default function ScenarioCompareOutput(props) {
                 </Grid>
                 <Grid item xs={12}>
                     <Box sx={{display: 'flex', justifyContent: 'center'}}>
-                        <Typography noWrap style={styles.kpiValue}>Scenario</Typography>
+                        <Typography noWrap style={styles.kpiValue}>{scenarios[primaryScenarioIndex].name}</Typography>
                     </Box>
                 </Grid>
                 <Grid item xs={12}>
                     <Box sx={{display: 'flex', justifyContent: 'center'}}>
-                        <Typography noWrap style={styles.kpiReferenceValue}>vs Reference</Typography>
+                        <Typography noWrap style={styles.kpiReferenceValue}>vs {scenarios[referenceScenarioIndex].name}</Typography>
                     </Box>
                 </Grid>
                 </Grid>


### PR DESCRIPTION
- fix bug that occurred when a draft was the first scenario in the list and defaulted to the compare page reference scenario
- changed "Scenario vs Reference" -> "<primary scenario name> vs <reference scenario name>"